### PR TITLE
Match Macy breakpoints with CSS media queries.

### DIFF
--- a/dist/macy.js
+++ b/dist/macy.js
@@ -244,7 +244,7 @@
     var nl = cache.container.querySelectorAll(selector);
     var arr = [];
     for (var i = nl.length - 1; i >= 0; i--) {
-      if (nl[i].offsetParent !== null) {
+      if (nl[i].parentNode !== null) {
         arr.unshift(nl[i]);
       }
     }

--- a/dist/macy.js
+++ b/dist/macy.js
@@ -241,7 +241,7 @@
     return document.querySelector(selector);
   };
   var eles = function(selector) {
-    var nl = document.querySelectorAll(selector);
+    var nl = cache.container.querySelectorAll(selector);
     var arr = [];
     for (var i = nl.length - 1; i >= 0; i--) {
       if (nl[i].offsetParent !== null) {

--- a/dist/macy.js
+++ b/dist/macy.js
@@ -52,10 +52,10 @@
   };
   var imgsRequired, currentlyLoaded;
   var getCurrentColumns = function() {
-    var docWidth = document.body.clientWidth;
+    var fullWidth = window.innerWidth;
     var noOfColumns;
     for (var widths in cache.options.breakAt) {
-      if (docWidth < widths) {
+      if (fullWidth < widths) {
         noOfColumns = cache.options.breakAt[widths];
         break;
       }

--- a/dist/macy.js
+++ b/dist/macy.js
@@ -241,7 +241,7 @@
     return document.querySelector(selector);
   };
   var eles = function(selector) {
-    var nl = cache.container.querySelectorAll(selector);
+    var nl = document.querySelectorAll(selector);
     var arr = [];
     for (var i = nl.length - 1; i >= 0; i--) {
       if (nl[i].offsetParent !== null) {

--- a/dist/macy.js
+++ b/dist/macy.js
@@ -244,7 +244,7 @@
     var nl = cache.container.querySelectorAll(selector);
     var arr = [];
     for (var i = nl.length - 1; i >= 0; i--) {
-      if (nl[i].parentNode !== null) {
+      if (nl[i].offsetParent !== null) {
         arr.unshift(nl[i]);
       }
     }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "macy",
   "description": "Macy is a lightweight, dependency free, masonry layout library",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "author": {
     "name": "Big Bite Creative",
     "url": "http://bigbitecreative.com",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "macy",
   "description": "Macy is a lightweight, dependency free, masonry layout library",
-  "version": "1.1.3",
+  "version": "1.1.2",
   "author": {
     "name": "Big Bite Creative",
     "url": "http://bigbitecreative.com",

--- a/src/macy.js
+++ b/src/macy.js
@@ -407,7 +407,7 @@
     var arr = [];
 
     for (var i = nl.length - 1; i >= 0; i--) {
-      if (nl[i].offsetParent !== null) {
+      if (nl[i].parentNode !== null) {
         arr.unshift(nl[i]);
       }
     }

--- a/src/macy.js
+++ b/src/macy.js
@@ -403,7 +403,7 @@
    * @return {Array}           - An array of all visible elements with that selector
    */
   var eles = function (selector) {
-    var nl = cache.container.querySelectorAll(selector);
+    var nl = document.querySelectorAll(selector);
     var arr = [];
 
     for (var i = nl.length - 1; i >= 0; i--) {

--- a/src/macy.js
+++ b/src/macy.js
@@ -85,11 +85,11 @@
    * @return {Number} - The number of colummns
    */
   var getCurrentColumns = function () {
-    var docWidth = document.body.clientWidth;
+    var fullWidth = window.innerWidth;
     var noOfColumns;
 
     for (var widths in cache.options.breakAt) {
-      if (docWidth < widths) {
+      if (fullWidth < widths) {
         noOfColumns = cache.options.breakAt[widths];
 
         break;

--- a/src/macy.js
+++ b/src/macy.js
@@ -407,7 +407,7 @@
     var arr = [];
 
     for (var i = nl.length - 1; i >= 0; i--) {
-      if (nl[i].parentNode !== null) {
+      if (nl[i].offsetParent !== null) {
         arr.unshift(nl[i]);
       }
     }

--- a/src/macy.js
+++ b/src/macy.js
@@ -403,7 +403,7 @@
    * @return {Array}           - An array of all visible elements with that selector
    */
   var eles = function (selector) {
-    var nl = document.querySelectorAll(selector);
+    var nl = cache.container.querySelectorAll(selector);
     var arr = [];
 
     for (var i = nl.length - 1; i >= 0; i--) {


### PR DESCRIPTION
Using window.innerWidth instead of document.body.clientWidth.  Reason: CSS media queries include the scrollbar in measuring the width of the document, whereas document.body.clientWidth does not.  This creates issues with matching up media query styles with Macy breakpoints.  window.innerWidth, however, does include the scrollbar and will fix this issue.